### PR TITLE
Set for uploading to RubyGems

### DIFF
--- a/before_render.gemspec
+++ b/before_render.gemspec
@@ -14,4 +14,6 @@ Gem::Specification.new do |gem|
   gem.name          = "before_render"
   gem.require_paths = ["lib"]
   gem.version       = BeforeRender::VERSION
+
+  gem.add_dependency 'rails', '~> 4.0'
 end

--- a/lib/before_render/version.rb
+++ b/lib/before_render/version.rb
@@ -1,3 +1,3 @@
 module BeforeRender
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Incremented the minor version number and added a dependency on Rails 4.x to match the compatibility restriction. The version on RubyGems is the Rails 3 version and I thought it'd be nice to have this version available there.